### PR TITLE
More Python 3 compatibility enhancements

### DIFF
--- a/django_rules/backends.py
+++ b/django_rules/backends.py
@@ -1,21 +1,16 @@
 # -*- coding: utf-8 -*-
 import inspect
-
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import User, AnonymousUser
 
 try:
     from importlib import import_module
 except ImportError:  # python = 2.6
     from django.utils.importlib import import_module  # NOQA
 
-
-from models import RulePermission
-from exceptions import NotBooleanPermission
-from exceptions import NonexistentFieldName
-from exceptions import NonexistentPermission
-from exceptions import RulesError
+from .exceptions import NonexistentFieldName, NonexistentPermission, NotBooleanPermission, RulesError
+from .models import RulePermission
 
 
 class ObjectPermissionBackend(object):
@@ -33,7 +28,7 @@ class ObjectPermissionBackend(object):
         If it exists returns the value of obj.field_name or obj.field_name() in case
         the field is a method.
         """
-        
+
         if obj is None:
             return False
 
@@ -41,24 +36,24 @@ class ObjectPermissionBackend(object):
             user_obj = User.objects.get(pk=settings.ANONYMOUS_USER_ID)
 
         # Centralized authorizations
-        # You need to define a module in settings.CENTRAL_AUTHORIZATIONS that has a 
+        # You need to define a module in settings.CENTRAL_AUTHORIZATIONS that has a
         # central_authorizations function inside
         if hasattr(settings, 'CENTRAL_AUTHORIZATIONS'):
             module = getattr(settings, 'CENTRAL_AUTHORIZATIONS')
 
             try:
                 mod = import_module(module)
-            except ImportError, e:
+            except ImportError as e:
                 raise RulesError('Error importing central authorizations module %s: "%s"' % (module, e))
 
             try:
                 central_authorizations = getattr(mod, 'central_authorizations')
             except AttributeError:
                 raise RulesError('Error module %s does not have a central_authorization function"' % (module))
-            
+
             try:
                 is_authorized = central_authorizations(user_obj, perm)
-                # If the value returned is a boolean we pass it up and stop checking 
+                # If the value returned is a boolean we pass it up and stop checking
                 # If not, we continue checking
                 if isinstance(is_authorized, bool):
                     return is_authorized
@@ -69,12 +64,12 @@ class ObjectPermissionBackend(object):
         # Note:
         # is_active and is_superuser are checked by default in django.contrib.auth.models
         # lines from 301-306 in Django 1.2.3
-	# If this checks dissapear in mainstream, tests will fail, so we won't double check them :)
+        # If this checks dissapear in mainstream, tests will fail, so we won't double check them :)
         ctype = ContentType.objects.get_for_model(obj)
 
         # We get the rule data and return the value of that rule
         try:
-            rule = RulePermission.objects.get(codename = perm, content_type = ctype)
+            rule = RulePermission.objects.get(codename=perm, content_type=ctype)
         except RulePermission.DoesNotExist:
             return False
 
@@ -82,25 +77,32 @@ class ObjectPermissionBackend(object):
         try:
             bound_field = getattr(obj, rule.field_name)
         except AttributeError:
-            raise NonexistentFieldName("Field_name %s from rule %s does not longer exist in model %s. \
-                                        The rule is obsolete!", (rule.field_name, rule.codename, rule.content_type.model))
+            raise NonexistentFieldName(
+                "Field_name %s from rule %s does not longer exist in model %s. \
+                                        The rule is obsolete!",
+                (rule.field_name, rule.codename, rule.content_type.model),
+            )
 
         if not isinstance(bound_field, bool) and not callable(bound_field):
-            raise NotBooleanPermission("Attribute %s from model %s on rule %s does not return a boolean value",
-                                        (rule.field_name, rule.content_type.model, rule.codename))
+            raise NotBooleanPermission(
+                "Attribute %s from model %s on rule %s does not return a boolean value",
+                (rule.field_name, rule.content_type.model, rule.codename),
+            )
 
         if not callable(bound_field):
             is_authorized = bound_field
         else:
             # Otherwise it is a callabe bound_field
             # Let's see if we pass or not user_obj as a parameter
-            if (len(inspect.getargspec(bound_field)[0]) == 2):
+            if len(inspect.getargspec(bound_field)[0]) == 2:
                 is_authorized = bound_field(user_obj)
             else:
                 is_authorized = bound_field()
 
             if not isinstance(is_authorized, bool):
-                raise NotBooleanPermission("Callable %s from model %s on rule %s does not return a boolean value",
-                                            (rule.field_name, rule.content_type.model, rule.codename))
+                raise NotBooleanPermission(
+                    "Callable %s from model %s on rule %s does not return a boolean value",
+                    (rule.field_name, rule.content_type.model, rule.codename),
+                )
 
         return is_authorized

--- a/django_rules/decorators.py
+++ b/django_rules/decorators.py
@@ -3,6 +3,9 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import NoReverseMatch, reverse
+from django.shortcuts import get_object_or_404
+from django.utils.functional import wraps
+from django.utils.http import urlquote
 
 from .backends import ObjectPermissionBackend, rule_cache
 from .exceptions import NonexistentPermission, RulesError

--- a/django_rules/models.py
+++ b/django_rules/models.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import inspect
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.contrib.contenttypes.models import ContentType
 
-from exceptions import NonexistentFieldName
-from exceptions import RulesError
+from .exceptions import NonexistentFieldName, RulesError
 
 
 class RulePermission(models.Model):
@@ -20,7 +19,6 @@ class RulePermission(models.Model):
     content_type = models.ForeignKey(ContentType)
     view_param_pk = models.CharField(max_length=30)
     description = models.CharField(max_length=140, null=True)
-
 
     def save(self, *args, **kwargs):
         """
@@ -41,14 +39,18 @@ class RulePermission(models.Model):
         if not hasattr(self.content_type.model_class(), self.field_name):
             # Search within attributes field names
             if not (self.field_name in self.content_type.model_class()._meta.get_all_field_names()):
-                raise NonexistentFieldName("Could not create rule: field_name %s of rule %s does not exist in model %s" %
-                                            (self.field_name, self.codename, self.content_type.model))
+                raise NonexistentFieldName(
+                    "Could not create rule: field_name %s of rule %s does not exist in model %s"
+                    % (self.field_name, self.codename, self.content_type.model)
+                )
         else:
             # Check if the method parameters are less than 2 including self in the count
             bound_field = getattr(self.content_type.model_class(), self.field_name)
             if callable(bound_field):
                 if len(inspect.getargspec(bound_field)[0]) > 2:
-                    raise RulesError("method %s from rule %s in model %s has too many parameters." %
-                                        (self.field_name, self.codename, self.content_type.model))
-        
+                    raise RulesError(
+                        "method %s from rule %s in model %s has too many parameters."
+                        % (self.field_name, self.codename, self.content_type.model)
+                    )
+
         super(RulePermission, self).save(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-reload(sys).setdefaultencoding("UTF-8")
+
 from setuptools import setup, find_packages
 from distutils.core import setup
 


### PR DESCRIPTION
Runs `2to3` on the py3 compatible version of `django-rules` we have. 

**Note**: This version is _not_ backwards compatible to Python 2! `2to3` is a one-way street (in lots of cases)