### PR TITLE
OG-131: fix: Modify forked `django-rules` repo so that `sync-rules` command works with Python 3

### DIFF
--- a/django_rules/utils.py
+++ b/django_rules/utils.py
@@ -4,8 +4,8 @@ import sys
 
 from django.contrib.contenttypes.models import ContentType
 
-from models import RulePermission
-    
+from .models import RulePermission
+
 def register(app_name, codename, model, field_name='', view_param_pk='', description=''):
     """
     Call this function in your rules.py to register your RulePermissions


### PR DESCRIPTION
## Linking

[OG-131](https://hiveco1.atlassian.net/browse/OG-131)

## Description

Running the command `manage.py sync-rules` doesn't work after the update to Python 3. Super small fix here basically just adds a preceding `.` on one of the imports!

## Testing
Was able to run `manage.py sync-rules` successfully after changing.

[OG-131]: https://hiveco1.atlassian.net/browse/OG-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ