### PR TITLE
fix: is_authenticated property

### DIFF
--- a/django_rules/backends.py
+++ b/django_rules/backends.py
@@ -51,7 +51,7 @@ class ObjectPermissionBackend(object):
         if obj is None:
             return False
 
-        if not user_obj.is_authenticated():
+        if not user_obj.is_authenticated:
             user_obj = User.objects.get(pk=settings.ANONYMOUS_USER_ID)
 
         # Centralized authorizations


### PR DESCRIPTION
- `django_rules/backends.py` — `is_authenticated()` -> `is_authenticated` (property since Django 1.10, `CallableBool` shim removed)